### PR TITLE
Añadir js a la pantalla de crear calendario

### DIFF
--- a/app/symfony/public/js/crear_calendario.js
+++ b/app/symfony/public/js/crear_calendario.js
@@ -1,0 +1,103 @@
+const fecha_festivo = document.getElementById("nuevoFestivo");
+const descripcion_festivo = document.getElementById("descNuevoFestivo");
+const btn_anadir = document.getElementById("btn-añadir");
+const lista_festivos = document.getElementById("listaFestivos");
+const fecha_inicio = document.getElementById("fechaInicio");
+const fecha_fin = document.getElementById("fechaFin");
+
+// CONTROL BOTÓN AÑADIR - SE DEBEN RELLENAR TANTO LA FECHA COMO LA DESCRIPCIÓN DEL FESTIVO PARA HABILITAR EL BOTÓN
+btn_anadir.disabled = true;
+
+fecha_festivo.addEventListener("change", () => {
+    controlBotonAnadir();
+});
+
+descripcion_festivo.addEventListener("keyup", () => {
+    controlBotonAnadir();
+});
+
+function controlBotonAnadir() {
+    btn_anadir.disabled = !(fecha_festivo.value !== "" && descripcion_festivo.value !== "");
+}
+
+// AÑADIR LINEA CON EL NUEVO FESTIVO
+btn_anadir.addEventListener("click", () => {
+    crearNuevoFestivo(fecha_festivo.value, descripcion_festivo.value)
+    fecha_festivo.value = "";
+    descripcion_festivo.value = "";
+    btn_anadir.disabled = true;
+});
+
+function crearNuevoFestivo(fecha, descripcion) {
+    let nuevo_festivo = document.createElement("li");
+    nuevo_festivo.className = "list-group-item d-flex justify-content-between align-items-center";
+
+    let icono = document.createElement("i");
+    icono.className = "bi bi-x-lg";
+
+    let span = document.createElement("span");
+    span.className = "badge badge-primary badge-pill";
+    span.appendChild(icono);
+
+    let link = document.createElement("a");
+    link.setAttribute('type', 'button');
+    link.appendChild(span);
+    link.addEventListener('click', () => {
+        lista_festivos.removeChild(link.parentElement);
+
+    })
+
+    fecha = convertirFechaPantalla(fecha)   // de utils.js
+    nuevo_festivo.innerText = fecha + " - " + descripcion
+    nuevo_festivo.appendChild(link);
+
+    lista_festivos.appendChild(nuevo_festivo)
+}
+
+
+// LISTENER BORRAR FESTIVOS
+document.querySelectorAll('.eliminar-festivo').forEach(elem => {
+    elem.addEventListener('click', () => {
+        lista_festivos.removeChild(elem.parentElement);
+    })
+})
+
+
+// COMPROBACIONES FECHA INICIO Y FECHA FIN
+fecha_inicio.addEventListener("change", event => {
+    comprobarFechaInicio()
+});
+
+
+fecha_fin.addEventListener("change", event => {
+    comprobarFechaFin()
+});
+
+
+function comprobarFechaInicio() {
+    let fecha = fecha_inicio.value;
+    if (comprobarFechaMayorFechaActual(fecha)) {
+        if (comprobarFechaMayorFechaActual(fecha_fin.value) && comprobarFechaMayor(fecha_inicio.value, fecha_fin.value)){
+            fecha_inicio.classList.remove("is-invalid")
+            fecha_fin.classList.remove("is-invalid")
+        } else {
+            fecha_inicio.classList.add("is-invalid")
+        }
+    } else {
+        fecha_inicio.classList.add("is-invalid")
+    }
+}
+
+function comprobarFechaFin() {
+    let fecha = fecha_fin.value;
+    if (comprobarFechaMayorFechaActual(fecha)) {
+        if (comprobarFechaMayorFechaActual(fecha_inicio.value) && comprobarFechaMayor(fecha_inicio.value, fecha_fin.value)){
+            fecha_inicio.classList.remove("is-invalid")
+            fecha_fin.classList.remove("is-invalid")
+        } else {
+            fecha_fin.classList.add("is-invalid")
+        }
+    } else {
+        fecha_fin.classList.add("is-invalid")
+    }
+}

--- a/app/symfony/public/js/utils.js
+++ b/app/symfony/public/js/utils.js
@@ -1,0 +1,38 @@
+
+// Convertir la fecha de 2022-12-20 a 20/12/2022
+function convertirFechaPantalla(fecha) {
+    return fecha.split("-")[2] + "/" + fecha.split("-")[1] + "/" + fecha.split("-")[0];
+}
+
+// Devolver fecha de hoy
+function getFechaHoy(){
+    let fecha_actual = new Date()
+    let dia = fecha_actual.getDate()
+    let mes = fecha_actual.getMonth() + 1;
+    let ano = fecha_actual.getFullYear()
+    if (dia < 10) {
+        dia = "0" + dia
+    }
+    if (mes < 10) {
+        mes = "0" + mes
+    }
+    return ano + "" + mes + "" + dia    //Ej.: 20220520
+}
+
+// Comprobar que la fecha introducida es mayor a la fecha actual
+function comprobarFechaMayorFechaActual(fecha) {
+    let fecha_hoy = getFechaHoy()
+    fecha = fecha.split("-")[0] + "" + fecha.split("-")[1] + "" + fecha.split("-")[2];
+    return fecha >= fecha_hoy;
+}
+
+// Comprobar que la fecha final es mayor a la fecha inicio
+function comprobarFechaMayor(fechaInicio, fechaFin) {
+    if (fechaInicio !== "" && fechaFin !== "") {
+            fechaInicio = fechaInicio.split("-")[0] + "" + fechaInicio.split("-")[1] + "" + fechaInicio.split("-")[2];
+            fechaFin = fechaFin.split("-")[0] + "" + fechaFin.split("-")[1] + "" + fechaFin.split("-")[2];
+            return fechaInicio < fechaFin;
+    } else {
+        return true;
+    }
+}

--- a/app/symfony/templates/admin/crear_calendario.html.twig
+++ b/app/symfony/templates/admin/crear_calendario.html.twig
@@ -1,5 +1,11 @@
 {% extends 'base.html.twig' %}
 
+{%  block javascripts %}
+    {{ parent() }}
+    <script type="text/javascript" src="{{ asset('js/crear_calendario.js') }}" defer></script>
+    <script type="text/javascript" src="{{ asset('js/utils.js') }}" defer></script>
+{% endblock %}
+
 {% block body %}
 
     <body class="hold-transition layout-top-nav">
@@ -48,12 +54,14 @@
                                                 <div class="form-group">
                                                     <label for="fechaInicio">Fecha inicio</label>
                                                     <input type="date" class="form-control" id="fechaInicio">
+                                                    <span class="error invalid-feedback"> La fecha inicio tiene que ser mayor o igual a la fecha actual y menor a la fecha fin </span>
                                                 </div>
                                             </div>
                                             <div class="col-md-6">
                                                 <div class="form-group">
                                                     <label for="fechaFin">Fecha fin</label>
                                                     <input type="date" class="form-control" id="fechaFin">
+                                                    <span class="error invalid-feedback"> La fecha fin tiene que ser mayor o igual a la fecha actual y mayor a la fecha inicio </span>
                                                 </div>
                                             </div>
                                         </div>
@@ -62,11 +70,11 @@
                                                 <div class="form-group">
                                                     <label>Añadir días festivos del calendario</label>
                                                     <div class="input-group">
-                                                        <input type="date" class="form-control">
-                                                        <input type="text" class="form-control"
+                                                        <input id="nuevoFestivo" type="date" class="form-control">
+                                                        <input id="descNuevoFestivo" type="text" class="form-control"
                                                                placeholder="Descripción día festivo">
                                                         <div class="input-group-prepend">
-                                                            <button type="button"
+                                                            <button type="button" id="btn-añadir"
                                                                     class="btn btn-primary">Añadir</button>
                                                         </div>
                                                     </div>
@@ -75,20 +83,20 @@
                                         </div>
                                         <div class="row">
                                             <div class="col-md-6">
-                                                <ul class="list-group">
+                                                <ul id="listaFestivos" class="list-group">
                                                     <li class="list-group-item d-flex justify-content-between align-items-center">
                                                         01/01/2022 - Año nuevo
-                                                        <a><span class="badge badge-primary badge-pill"><i
+                                                        <a class="eliminar-festivo" type="button"><span class="badge badge-primary badge-pill"><i
                                                                         class="bi bi-x-lg"></i></span></a>
                                                     </li>
                                                     <li class="list-group-item d-flex justify-content-between align-items-center">
                                                         06/01/2022 - Día de reyes
-                                                        <a><span class="badge badge-primary badge-pill"><i
+                                                        <a class="eliminar-festivo" type="button"><span class="badge badge-primary badge-pill"><i
                                                                         class="bi bi-x-lg"></i></span></a>
                                                     </li>
                                                     <li class="list-group-item d-flex justify-content-between align-items-center">
                                                         19/03/2022 - Día del padre
-                                                        <a><span class="badge badge-primary badge-pill"><i
+                                                        <a class="eliminar-festivo" type="button"><span class="badge badge-primary badge-pill"><i
                                                                         class="bi bi-x-lg"></i></span></a>
                                                     </li>
                                                 </ul>


### PR DESCRIPTION
Añadir javascript para el comportamiento de la pantalla de crear_calendario. Validaciones de fechas y control de días festivos